### PR TITLE
Role based access control

### DIFF
--- a/contracts/Bank.sol
+++ b/contracts/Bank.sol
@@ -5,8 +5,8 @@ import "./BankStorage.sol";
 import "./ITellor.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 
 /**
  * @title Bank
@@ -14,10 +14,9 @@ import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
  * origination fees from users that borrow against their collateral.
  * The oracle for Bank is Tellor.
  */
-contract Bank is BankStorage, Ownable, Initializable {
+contract Bank is BankStorage, AccessControlEnumerable, Initializable {
     using SafeERC20 for IERC20;
 
-    address private _owner;
     address private _bankFactoryOwner;
 
     /*Events*/
@@ -50,13 +49,14 @@ contract Bank is BankStorage, Ownable, Initializable {
         address bankFactoryOwner,
         address payable oracleContract
     ) public initializer {
+        //set up as admin / owner
+        _setupRole(DEFAULT_ADMIN_ROLE, creator);
         reserve.interestRate = interestRate;
         reserve.originationFee = originationFee;
         reserve.collateralizationRatio = collateralizationRatio;
         reserve.oracleContract = oracleContract;
         reserve.liquidationPenalty = liquidationPenalty;
         reserve.period = period;
-        _owner = creator; // Make the creator the first admin
         _bankFactoryOwner = bankFactoryOwner;
         name = bankName;
     }
@@ -69,7 +69,7 @@ contract Bank is BankStorage, Ownable, Initializable {
         uint256 collateralTokenTellorRequestId,
         uint256 collateralTokenPriceGranularity,
         uint256 collateralTokenPrice
-    ) public onlyOwner {
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         require(collateral.tokenAddress == address(0) && collateralToken != address(0), "!setable");
         collateral.tokenAddress = collateralToken;
         collateral.price = collateralTokenPrice;
@@ -85,7 +85,10 @@ contract Bank is BankStorage, Ownable, Initializable {
         uint256 debtTokenTellorRequestId,
         uint256 debtTokenPriceGranularity,
         uint256 debtTokenPrice
-    ) public onlyOwner {
+    )
+        public
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
         require(debt.tokenAddress == address(0) && debtToken != address(0), "!setable");
         debt.tokenAddress = debtToken;
         debt.price = debtTokenPrice;
@@ -97,7 +100,7 @@ contract Bank is BankStorage, Ownable, Initializable {
      * @dev This function allows the Bank owner to deposit the reserve (debt tokens)
      * @param amount is the amount to deposit
      */
-    function reserveDeposit(uint256 amount) external onlyOwner {
+    function reserveDeposit(uint256 amount) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(amount > 0, "Amount is zero !!");
         reserve.debtBalance += amount;
         IERC20(debt.tokenAddress).safeTransferFrom(
@@ -113,7 +116,7 @@ contract Bank is BankStorage, Ownable, Initializable {
      *      Withdraws incur a 0.5% fee paid to the bankFactoryOwner
      * @param amount is the amount to withdraw
      */
-    function reserveWithdraw(uint256 amount) external onlyOwner {
+    function reserveWithdraw(uint256 amount) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(
             IERC20(debt.tokenAddress).balanceOf(address(this)) >= amount,
             "NOT ENOUGH DEBT TOKENS IN RESERVE"
@@ -130,7 +133,7 @@ contract Bank is BankStorage, Ownable, Initializable {
          Withdraws incur a 0.5% fee paid to the bankFactoryOwner
   * @param amount is the amount to withdraw
   */
-    function reserveWithdrawCollateral(uint256 amount) external onlyOwner {
+    function reserveWithdrawCollateral(uint256 amount) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(
             reserve.collateralBalance >= amount,
             "NOT ENOUGH COLLATERAL IN RESERVE"
@@ -149,13 +152,13 @@ contract Bank is BankStorage, Ownable, Initializable {
      * @dev Use this function to get and update the price for the collateral token
      * using the Tellor Oracle.
      */
-    function updateCollateralPrice() external onlyOwner {
-        bool ifRetrieve;
-        (
-            ifRetrieve,
-            collateral.price,
-            collateral.lastUpdatedAt
-        ) = getCurrentValue(collateral.tellorRequestId); //,now - 1 hours);
+    function updateCollateralPrice() external {
+        require(
+            hasRole(PRICE_UPDATER_ROLE, msg.sender) ||
+            hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "not price updater or admin");
+        (, collateral.price, collateral.lastUpdatedAt) = getCurrentValue(
+            collateral.tellorRequestId
+        ); //,now - 1 hours);
         emit PriceUpdate(collateral.tokenAddress, collateral.price);
     }
 
@@ -163,21 +166,26 @@ contract Bank is BankStorage, Ownable, Initializable {
      * @dev Use this function to get and update the price for the debt token
      * using the Tellor Oracle.
      */
-    function updateDebtPrice() external onlyOwner {
-        bool ifRetrieve;
-        (ifRetrieve, debt.price, debt.lastUpdatedAt) = getCurrentValue(
+    function updateDebtPrice() external {
+        require(
+            hasRole(PRICE_UPDATER_ROLE, msg.sender) ||
+            hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "not price updater or admin");
+        (, debt.price, debt.lastUpdatedAt) = getCurrentValue(
             debt.tellorRequestId
         ); //,now - 1 hours);
         emit PriceUpdate(debt.tokenAddress, debt.price);
     }
 
     /**
-     * @dev Anyone can use this function to liquidate a vault's debt,
+     * @dev Only keepers or admins can use this function to liquidate a vault's debt,
      * the bank admins gets the collateral liquidated, liquidated collateral
      * is charged a 10% fee which gets paid to the bankFactoryOwner
      * @param vaultOwner is the user the bank admins wants to liquidate
      */
-    function liquidate(address vaultOwner) external onlyOwner {
+    function liquidate(address vaultOwner) external {
+        require(
+            hasRole(KEEPER_ROLE, msg.sender) ||
+            hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "not keeper or admin");
         // Require undercollateralization
         require(
             getVaultCollateralizationRatio(vaultOwner) <
@@ -328,5 +336,39 @@ contract Bank is BankStorage, Ownable, Initializable {
         uint256 _value = oracle.retrieveData(_requestId, _time);
         if (_value > 0) return (true, _value, _time);
         return (false, 0, _time);
+    }
+
+    /**
+     * @dev Allows admin to add address to keeper role
+     * @param keeper address of new keeper
+     */
+    function addKeeper(address keeper) external {
+        require(keeper != address(0), "operation not allowed");
+        grantRole(KEEPER_ROLE, keeper);
+    }
+
+    /**
+     * @dev Allows admin to remove address from keeper role
+     * @param oldKeeper address of old keeper
+     */
+    function revokeKeeper(address oldKeeper) external {
+        revokeRole(KEEPER_ROLE, oldKeeper);
+    }
+
+    /**
+     * @dev Allows admin to add address to price updater role
+     * @param updater address of new price updater
+     */
+    function addPriceUpdater(address updater) external {
+        require(updater != address(0), "operation not allowed");
+        grantRole(PRICE_UPDATER_ROLE, updater);
+    }
+
+    /**
+     * @dev Allows admin to remove address from price updater role
+     * @param oldUpdater address of old price updater
+     */
+    function revokePriceUpdater(address oldUpdater) external {
+        revokeRole(PRICE_UPDATER_ROLE, oldUpdater);
     }
 }

--- a/contracts/Bank.sol
+++ b/contracts/Bank.sol
@@ -22,13 +22,13 @@ contract Bank is BankStorage, Ownable, Initializable {
 
     /*Events*/
     event ReserveDeposit(uint256 amount);
-    event ReserveWithdraw(address token, uint256 amount);
-    event VaultDeposit(address owner, uint256 amount);
-    event VaultBorrow(address borrower, uint256 amount);
-    event VaultRepay(address borrower, uint256 amount);
-    event VaultWithdraw(address borrower, uint256 amount);
-    event PriceUpdate(address token, uint256 price);
-    event Liquidation(address borrower, uint256 debtAmount);
+    event ReserveWithdraw(address indexed token, uint256 amount);
+    event VaultDeposit(address indexed owner, uint256 amount);
+    event VaultBorrow(address indexed borrower, uint256 amount);
+    event VaultRepay(address indexed borrower, uint256 amount);
+    event VaultWithdraw(address indexed borrower, uint256 amount);
+    event PriceUpdate(address indexed token, uint256 price);
+    event Liquidation(address indexed borrower, uint256 debtAmount);
 
     /*Constructor*/
     constructor(address payable oracleContract) {

--- a/contracts/Bank.sol
+++ b/contracts/Bank.sol
@@ -154,8 +154,8 @@ contract Bank is BankStorage, AccessControlEnumerable, Initializable {
      */
     function updateCollateralPrice() external {
         require(
-            hasRole(PRICE_UPDATER_ROLE, msg.sender) ||
-            hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "not price updater or admin");
+            hasRole(REPORTER_ROLE, msg.sender) ||
+            hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "not reporter or admin");
         (, collateral.price, collateral.lastUpdatedAt) = getCurrentValue(
             collateral.tellorRequestId
         ); //,now - 1 hours);
@@ -168,8 +168,8 @@ contract Bank is BankStorage, AccessControlEnumerable, Initializable {
      */
     function updateDebtPrice() external {
         require(
-            hasRole(PRICE_UPDATER_ROLE, msg.sender) ||
-            hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "not price updater or admin");
+            hasRole(REPORTER_ROLE, msg.sender) ||
+            hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "not reporter or admin");
         (, debt.price, debt.lastUpdatedAt) = getCurrentValue(
             debt.tellorRequestId
         ); //,now - 1 hours);
@@ -356,19 +356,19 @@ contract Bank is BankStorage, AccessControlEnumerable, Initializable {
     }
 
     /**
-     * @dev Allows admin to add address to price updater role
-     * @param updater address of new price updater
+     * @dev Allows admin to add address to reporter role
+     * @param updater address of new reporter
      */
-    function addPriceUpdater(address updater) external {
+    function addReporter(address updater) external {
         require(updater != address(0), "operation not allowed");
-        grantRole(PRICE_UPDATER_ROLE, updater);
+        grantRole(REPORTER_ROLE, updater);
     }
 
     /**
-     * @dev Allows admin to remove address from price updater role
-     * @param oldUpdater address of old price updater
+     * @dev Allows admin to remove address from reporter role
+     * @param oldUpdater address of old reporter
      */
-    function revokePriceUpdater(address oldUpdater) external {
-        revokeRole(PRICE_UPDATER_ROLE, oldUpdater);
+    function revokeReporter(address oldUpdater) external {
+        revokeRole(REPORTER_ROLE, oldUpdater);
     }
 }

--- a/contracts/BankStorage.sol
+++ b/contracts/BankStorage.sol
@@ -11,6 +11,10 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 contract BankStorage {
     /*Variables*/
     string name;
+    // role identifier for keeper that can make liquidations
+    bytes32 public constant KEEPER_ROLE = keccak256("KEEPER_ROLE");
+    // role identifier for price updater
+    bytes32 public constant PRICE_UPDATER_ROLE = keccak256("PRICE_UPDATER_ROLE");
 
     struct Reserve {
         uint256 collateralBalance;

--- a/contracts/BankStorage.sol
+++ b/contracts/BankStorage.sol
@@ -14,7 +14,7 @@ contract BankStorage {
     // role identifier for keeper that can make liquidations
     bytes32 public constant KEEPER_ROLE = keccak256("KEEPER_ROLE");
     // role identifier for price updater
-    bytes32 public constant PRICE_UPDATER_ROLE = keccak256("PRICE_UPDATER_ROLE");
+    bytes32 public constant REPORTER_ROLE = keccak256("REPORTER_ROLE");
 
     struct Reserve {
         uint256 collateralBalance;

--- a/test/bank.js
+++ b/test/bank.js
@@ -14,7 +14,11 @@ var Bank = artifacts.require("Bank");
 var CT = artifacts.require("GLDToken");
 var DT = artifacts.require("USDToken");
 
-contract("Bank", function(_accounts) {
+contract("Bank", function (_accounts) {
+  const DEFAULT_ADMIN_ROLE = "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const KEEPER_ROLE = web3.utils.soliditySha3("KEEPER_ROLE");
+  const PRICE_UPDATER_ROLE = web3.utils.soliditySha3("PRICE_UPDATER_ROLE");
+
   const INTEREST_RATE = 1200; // 12%
   const ORIGINATION_FEE = 100; // 1%
   const COLLATERALIZATION_RATIO = 150;
@@ -47,6 +51,12 @@ contract("Bank", function(_accounts) {
     await this.ct.transfer(_accounts[1], ether(new BN(500)));
     await this.dt.transfer(_accounts[1], ether(new BN(500)));
 
+    //set keepers
+    await this.bank.addKeeper(_accounts[3]);
+    await this.bank.addKeeper(_accounts[4]);
+    //set updaters
+    await this.bank.addPriceUpdater(_accounts[5]);
+    await this.bank.addPriceUpdater(_accounts[6]);
   });
 
   it('should create bank with correct parameters', async function () {
@@ -56,12 +66,20 @@ contract("Bank", function(_accounts) {
     const liquidationPenalty = await this.bank.getLiquidationPenalty();
     const reserveBalance = await this.bank.getReserveBalance();
     const reserveCollateralBalance = await this.bank.getReserveCollateralBalance();
-    const owner = await this.bank.owner();
-    const dtAddress = await this.bank.getDebtTokenAddress()
-    const ctAddress = await this.bank.getCollateralTokenAddress()
-    const name = await this.bank.getName()
+    const isAdmin = await this.bank.hasRole(DEFAULT_ADMIN_ROLE, _accounts[0]);
+    const isKeeper1 = await this.bank.hasRole(KEEPER_ROLE, _accounts[3]);
+    const isKeeper2 = await this.bank.hasRole(KEEPER_ROLE, _accounts[4]);
+    const isPriceUpdater1 = await this.bank.hasRole(PRICE_UPDATER_ROLE, _accounts[5]);
+    const isPriceUpdater2 = await this.bank.hasRole(PRICE_UPDATER_ROLE, _accounts[6]);
+    const dtAddress = await this.bank.getDebtTokenAddress();
+    const ctAddress = await this.bank.getCollateralTokenAddress();
+    const name = await this.bank.getName();
 
-    assert.equal(owner, _accounts[0]);
+    assert.ok(isAdmin);
+    assert.ok(isKeeper1);
+    assert.ok(isKeeper2);
+    assert.ok(isPriceUpdater1);
+    assert.ok(isPriceUpdater2);
     assert.equal(name, BANK_NAME);
     assert.equal(interestRate, INTEREST_RATE);
     assert.equal(originationFee, ORIGINATION_FEE);
@@ -73,7 +91,46 @@ contract("Bank", function(_accounts) {
     assert.equal(ctAddress, this.ct.address);
   });
 
-  it('should allow owner to deposit reserves', async function () {
+  it('only admin role should add / remove new roles', async function () {
+    const admin = await this.bank.getRoleMember(DEFAULT_ADMIN_ROLE, 0);
+    expect(await this.bank.getRoleMemberCount(KEEPER_ROLE)).to.be.bignumber.equal(new BN(2));
+    expect(await this.bank.getRoleMemberCount(PRICE_UPDATER_ROLE)).to.be.bignumber.equal(new BN(2));
+
+    //keeper adds another keeper
+    let keeper = await this.bank.getRoleMember(KEEPER_ROLE, 0);
+    expectRevert(this.bank.addKeeper(_accounts[8], { from: keeper }), "AccessControl");
+
+    //price updater adds another keeper
+    let priceUpdater = await this.bank.getRoleMember(PRICE_UPDATER_ROLE, 0);
+    expectRevert(this.bank.addPriceUpdater(_accounts[8], { from: priceUpdater }), "AccessControl");
+
+    //admin add new keeper
+    this.bank.addKeeper(_accounts[8], { from: admin });
+    expect(await this.bank.getRoleMemberCount(KEEPER_ROLE)).to.be.bignumber.equal(new BN(3));
+
+    //admin add new price updater
+    this.bank.addPriceUpdater(_accounts[8], { from: admin });
+    expect(await this.bank.getRoleMemberCount(PRICE_UPDATER_ROLE)).to.be.bignumber.equal(new BN(3));
+
+    //keeper remove keeper
+    keeper = await this.bank.getRoleMember(KEEPER_ROLE, 0);
+    const removeKeeper = await this.bank.getRoleMember(KEEPER_ROLE, 1);
+    expectRevert(this.bank.revokeKeeper(removeKeeper, { from: keeper }), "AccessControl");
+
+    //keeper remove keeper
+    priceUpdater = await this.bank.getRoleMember(PRICE_UPDATER_ROLE, 0);
+    const removePriceUpdater = await this.bank.getRoleMember(PRICE_UPDATER_ROLE, 1);
+    expectRevert(this.bank.revokePriceUpdater(removePriceUpdater, { from: priceUpdater }), "AccessControl");
+
+    //admin removes keeper and updater
+    this.bank.revokeKeeper(removeKeeper, { from: admin });
+    this.bank.revokePriceUpdater(removePriceUpdater, { from: admin });
+
+    expect(await this.bank.getRoleMemberCount(KEEPER_ROLE)).to.be.bignumber.equal(new BN(2));
+    expect(await this.bank.getRoleMemberCount(PRICE_UPDATER_ROLE)).to.be.bignumber.equal(new BN(2));
+  })
+
+  it('should allow admin to deposit reserves', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
     const reserveBalance = await this.bank.getReserveBalance();
@@ -82,7 +139,7 @@ contract("Bank", function(_accounts) {
     expect(tokenBalance).to.be.bignumber.equal(this.depositAmount);
   });
 
-  it('should allow owner to withdraw reserves', async function () {
+  it('should allow admin to withdraw reserves', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
     const beforeReserveBalance = await this.bank.getReserveBalance();
@@ -99,33 +156,31 @@ contract("Bank", function(_accounts) {
     expect(bankFactoryOwnerBalance).to.be.bignumber.equal(feeAmt);
   });
 
-
-  it('should not allow non-owner to deposit reserves', async function () {
-    await expectRevert(this.bank.reserveDeposit(ether(new BN(100)), {from: _accounts[1]}), "Ownable: caller is not the owner");
+  it('should not allow non-admin to deposit reserves', async function () {
+    expectRevert(this.bank.reserveDeposit(ether(new BN(100)), { from: _accounts[1] }), "AccessControl");
   });
 
-  it('should not allow non-owner to withdraw reserves', async function () {
-    await expectRevert(this.bank.reserveWithdraw(ether(new BN(100)), {from: _accounts[1]}), "Ownable: caller is not the owner");
+  it('should not allow non-admin to withdraw reserves', async function () {
+    expectRevert(this.bank.reserveWithdraw(ether(new BN(100)), { from: _accounts[1] }), "AccessControl");
   });
 
   it('should allow user to deposit collateral into vault', async function () {
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    const collateralAmount = await this.bank.getVaultCollateralAmount({from: _accounts[1]});
-    const debtAmount = await this.bank.getVaultDebtAmount({from: _accounts[1]});
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    const collateralAmount = await this.bank.getVaultCollateralAmount({ from: _accounts[1] });
+    const debtAmount = await this.bank.getVaultDebtAmount({ from: _accounts[1] });
     const tokenBalance = await this.ct.balanceOf(this.bank.address);
     expect(collateralAmount).to.be.bignumber.equal(this.depositAmount);
     expect(debtAmount).to.be.bignumber.equal(this.zero);
     expect(tokenBalance).to.be.bignumber.equal(this.depositAmount);
   });
 
-
   it('should allow user to withdraw collateral from vault', async function () {
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultWithdraw(this.depositAmount, {from: _accounts[1]});
-    const collateralAmount = await this.bank.getVaultCollateralAmount({from: _accounts[1]});
-    const debtAmount = await this.bank.getVaultDebtAmount({from: _accounts[1]});
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultWithdraw(this.depositAmount, { from: _accounts[1] });
+    const collateralAmount = await this.bank.getVaultCollateralAmount({ from: _accounts[1] });
+    const debtAmount = await this.bank.getVaultDebtAmount({ from: _accounts[1] });
     const tokenBalance = await this.ct.balanceOf(this.bank.address);
     expect(collateralAmount).to.be.bignumber.equal(this.zero);
     expect(debtAmount).to.be.bignumber.equal(this.zero);
@@ -135,32 +190,32 @@ contract("Bank", function(_accounts) {
   it('should not allow user to withdraw more collateral than they have in vault', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await expectRevert(this.bank.vaultWithdraw(this.largeDepositAmount, {from: _accounts[1]}), "CANNOT WITHDRAW MORE COLLATERAL");
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await expectRevert(this.bank.vaultWithdraw(this.largeDepositAmount, { from: _accounts[1] }), "CANNOT WITHDRAW MORE COLLATERAL");
   });
 
   it('should not allow user to withdraw collateral from vault if undercollateralized', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultBorrow(this.borrowAmount, {from: _accounts[1]});
-    await expectRevert(this.bank.vaultWithdraw(this.depositAmount, {from: _accounts[1]}), "CANNOT UNDERCOLLATERALIZE VAULT");
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultBorrow(this.borrowAmount, { from: _accounts[1] });
+    await expectRevert(this.bank.vaultWithdraw(this.depositAmount, { from: _accounts[1] }), "CANNOT UNDERCOLLATERALIZE VAULT");
   });
 
   it('should add origination fee to a vault\'s borrowed amount', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultBorrow(this.borrowAmount, {from: _accounts[1]});
-    const collateralAmount = await this.bank.getVaultCollateralAmount({from: _accounts[1]});
-    const debtAmount = await this.bank.getVaultDebtAmount({from: _accounts[1]});
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultBorrow(this.borrowAmount, { from: _accounts[1] });
+    const collateralAmount = await this.bank.getVaultCollateralAmount({ from: _accounts[1] });
+    const debtAmount = await this.bank.getVaultDebtAmount({ from: _accounts[1] });
     expect(collateralAmount).to.be.bignumber.equal(this.depositAmount);
     // Calculate borrowed amount
     var b_amount = parseInt(this.borrowAmount);
-    b_amount += (b_amount * ORIGINATION_FEE)/10000;
+    b_amount += (b_amount * ORIGINATION_FEE) / 10000;
     expect(debtAmount).to.be.bignumber.equal(b_amount.toString());
 
     const collateralBalance = await this.ct.balanceOf(this.bank.address);
@@ -172,14 +227,14 @@ contract("Bank", function(_accounts) {
   it('should allow the user to borrow', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultBorrow(this.smallBorrowAmount, {from: _accounts[1]});
-    await time.increase(60*60*24*2+10);
-    await this.bank.vaultBorrow(this.smallBorrowAmount, {from: _accounts[1]});
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultBorrow(this.smallBorrowAmount, { from: _accounts[1] });
+    await time.increase(60 * 60 * 24 * 2 + 10);
+    await this.bank.vaultBorrow(this.smallBorrowAmount, { from: _accounts[1] });
     //await this.bank.vaultBorrow(this.smallBorrowAmount, {from: _accounts[1]});
-    const collateralAmount = await this.bank.getVaultCollateralAmount({from: _accounts[1]});
-    const debtAmount = await this.bank.getVaultDebtAmount({from: _accounts[1]});
+    const collateralAmount = await this.bank.getVaultCollateralAmount({ from: _accounts[1] });
+    const debtAmount = await this.bank.getVaultDebtAmount({ from: _accounts[1] });
     expect(collateralAmount).to.be.bignumber.equal(this.depositAmount);
     // Calculate borrowed amount, use pays origination fee on 2 borrows
     var s_amount = new BN(this.smallBorrowAmount);
@@ -199,21 +254,21 @@ contract("Bank", function(_accounts) {
   it('should not allow the user to borrow above collateralization ratio', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await expectRevert(this.bank.vaultBorrow("66600000000000000000", {from: _accounts[1]}), "NOT ENOUGH COLLATERAL");
-    await this.bank.vaultBorrow(ether(new BN(66)), {from: _accounts[1]});
-    await expectRevert(this.bank.vaultBorrow(ether(new BN(1)), {from: _accounts[1]}), "NOT ENOUGH COLLATERAL");
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await expectRevert(this.bank.vaultBorrow("66600000000000000000", { from: _accounts[1] }), "NOT ENOUGH COLLATERAL");
+    await this.bank.vaultBorrow(ether(new BN(66)), { from: _accounts[1] });
+    await expectRevert(this.bank.vaultBorrow(ether(new BN(1)), { from: _accounts[1] }), "NOT ENOUGH COLLATERAL");
   });
 
   it('should accrue interest on a vault\'s borrowed amount', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultBorrow(this.borrowAmount, {from: _accounts[1]});
-    await time.increase(60*60*24*2+10) // Let two days pass
-    const repayAmount = await this.bank.getVaultRepayAmount({from: _accounts[1]});
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultBorrow(this.borrowAmount, { from: _accounts[1] });
+    await time.increase(60 * 60 * 24 * 2 + 10) // Let two days pass
+    const repayAmount = await this.bank.getVaultRepayAmount({ from: _accounts[1] });
     var b_amount = new BN(this.borrowAmount);
     b_amount = b_amount.add(b_amount.mul(new BN(ORIGINATION_FEE)).div(new BN(10000)));
     var f_b_amount = b_amount.add(b_amount.mul(new BN(INTEREST_RATE)).div(new BN(10000)).div(new BN(365))); // Day 1 interest rate
@@ -229,22 +284,22 @@ contract("Bank", function(_accounts) {
   it('should accrue interest on a vault\'s borrowed amount with repayment', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultBorrow(this.borrowAmount, {from: _accounts[1]});
-    await time.increase(60*60*24+10) // Let one days pass
-    var repayAmount = await this.bank.getVaultRepayAmount({from: _accounts[1]});
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultBorrow(this.borrowAmount, { from: _accounts[1] });
+    await time.increase(60 * 60 * 24 + 10) // Let one days pass
+    var repayAmount = await this.bank.getVaultRepayAmount({ from: _accounts[1] });
     var b_amount = new BN(this.borrowAmount);
     b_amount = b_amount.add(b_amount.mul(new BN(ORIGINATION_FEE)).div(new BN(10000)));
     b_amount = b_amount.add(b_amount.mul(new BN(INTEREST_RATE)).div(new BN(10000)).div(new BN(365))); // Day 1 interest rate
     expect(repayAmount).to.be.bignumber.equal(b_amount.toString());
 
-    await this.dt.approve(this.bank.address, this.smallBorrowAmount, {from: _accounts[1]});
-    await this.bank.vaultRepay(this.smallBorrowAmount, {from: _accounts[1]});
-    await time.increase(60*60*24+10) // Let one days pass
+    await this.dt.approve(this.bank.address, this.smallBorrowAmount, { from: _accounts[1] });
+    await this.bank.vaultRepay(this.smallBorrowAmount, { from: _accounts[1] });
+    await time.increase(60 * 60 * 24 + 10) // Let one days pass
     b_amount = b_amount.sub(this.smallBorrowAmount);
     b_amount = b_amount.add(b_amount.mul(new BN(INTEREST_RATE)).div(new BN(10000)).div(new BN(365))); // Day 1 interest rate
-    var repayAmount = await this.bank.getVaultRepayAmount({from: _accounts[1]});
+    var repayAmount = await this.bank.getVaultRepayAmount({ from: _accounts[1] });
     expect(repayAmount).to.be.bignumber.equal(b_amount.toString());
 
     const collateralBalance = await this.ct.balanceOf(this.bank.address);
@@ -257,14 +312,14 @@ contract("Bank", function(_accounts) {
   it('should allow user to withdraw after debt repayment', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultBorrow(this.borrowAmount, {from: _accounts[1]});
-    await time.increase(60*60*24*2+10) // Let two days pass
-    const repayAmount = await this.bank.getVaultRepayAmount({from: _accounts[1]});
-    await this.dt.approve(this.bank.address, repayAmount, {from: _accounts[1]});
-    await this.bank.vaultRepay(repayAmount, {from: _accounts[1]});
-    const debtAmount = await this.bank.getVaultDebtAmount({from: _accounts[1]});
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultBorrow(this.borrowAmount, { from: _accounts[1] });
+    await time.increase(60 * 60 * 24 * 2 + 10) // Let two days pass
+    const repayAmount = await this.bank.getVaultRepayAmount({ from: _accounts[1] });
+    await this.dt.approve(this.bank.address, repayAmount, { from: _accounts[1] });
+    await this.bank.vaultRepay(repayAmount, { from: _accounts[1] });
+    const debtAmount = await this.bank.getVaultDebtAmount({ from: _accounts[1] });
     expect(debtAmount).to.be.bignumber.equal(this.zero);
     var b_amount = new BN(this.borrowAmount);
     b_amount = b_amount.add(b_amount.mul(new BN(ORIGINATION_FEE)).div(new BN(10000)));
@@ -280,19 +335,19 @@ contract("Bank", function(_accounts) {
   it('should not allow user to withdraw without debt repayment', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultBorrow(this.borrowAmount, {from: _accounts[1]});
-    await time.increase(60*60*24*2+10) // Let two days pass
-    await expectRevert(this.bank.vaultWithdraw(this.depositAmount, {from: _accounts[1]}), "CANNOT UNDERCOLLATERALIZE VAUL");
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultBorrow(this.borrowAmount, { from: _accounts[1] });
+    await time.increase(60 * 60 * 24 * 2 + 10) // Let two days pass
+    await expectRevert(this.bank.vaultWithdraw(this.depositAmount, { from: _accounts[1] }), "CANNOT UNDERCOLLATERALIZE VAUL");
   });
 
   it('should not allow user to borrow below the collateralization ratio', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await expectRevert(this.bank.vaultBorrow(this.largeBorrowAmount, {from: _accounts[1]}), "NOT ENOUGH COLLATERAL");
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await expectRevert(this.bank.vaultBorrow(this.largeBorrowAmount, { from: _accounts[1] }), "NOT ENOUGH COLLATERAL");
   });
 
   xit('should calculate correct collateralization ratio for a user\'s vault', async function () {
@@ -301,14 +356,14 @@ contract("Bank", function(_accounts) {
     await this.bank.reserveDeposit(this.depositAmount);
 
     // The first price for the collateral and debt
-    await web3.eth.sendTransaction({to:this.oa,from:_accounts[0],gas:4000000,data:this.oracle2.methods.requestData("USDT","USDT/USD",1000,0).encodeABI()})
-    for(var i = 0;i <=4 ;i++){
-      await web3.eth.sendTransaction({to: this.oracle.address,from:_accounts[i],gas:4000000,data:this.oracle2.methods.submitMiningSolution("nonce", 1, 1000).encodeABI()})
+    await web3.eth.sendTransaction({ to: this.oa, from: _accounts[0], gas: 4000000, data: this.oracle2.methods.requestData("USDT", "USDT/USD", 1000, 0).encodeABI() })
+    for (var i = 0; i <= 4; i++) {
+      await web3.eth.sendTransaction({ to: this.oracle.address, from: _accounts[i], gas: 4000000, data: this.oracle2.methods.submitMiningSolution("nonce", 1, 1000).encodeABI() })
     }
 
-    await web3.eth.sendTransaction({to:this.oa,from:_accounts[0],gas:4000000,data:this.oracle2.methods.requestData("GLD","GLD/USD",1000,0).encodeABI()})
-    for(var i = 0;i <=4 ;i++){
-      await web3.eth.sendTransaction({to: this.oracle.address,from:_accounts[i],gas:4000000,data:this.oracle2.methods.submitMiningSolution("nonce", 2, 1700000).encodeABI()})
+    await web3.eth.sendTransaction({ to: this.oa, from: _accounts[0], gas: 4000000, data: this.oracle2.methods.requestData("GLD", "GLD/USD", 1000, 0).encodeABI() })
+    for (var i = 0; i <= 4; i++) {
+      await web3.eth.sendTransaction({ to: this.oracle.address, from: _accounts[i], gas: 4000000, data: this.oracle2.methods.submitMiningSolution("nonce", 2, 1700000).encodeABI() })
     }
     await this.bank.updateCollateralPrice();
     await this.bank.updateDebtPrice();
@@ -320,9 +375,9 @@ contract("Bank", function(_accounts) {
 
     await this.dt.approve(this.bank.address, this.largeDepositAmount);
     await this.bank.reserveDeposit(this.largeDepositAmount);
-    await this.ct.approve(this.bank.address, ether(this.one), {from: _accounts[1]});
-    await this.bank.vaultDeposit(ether(this.one), {from: _accounts[1]});
-    await this.bank.vaultBorrow(ether(new BN(1100)), {from: _accounts[1]});
+    await this.ct.approve(this.bank.address, ether(this.one), { from: _accounts[1] });
+    await this.bank.vaultDeposit(ether(this.one), { from: _accounts[1] });
+    await this.bank.vaultBorrow(ether(new BN(1100)), { from: _accounts[1] });
     const collateralizationRatio = await this.bank.getVaultCollateralizationRatio(_accounts[1]);
     expect(collateralizationRatio).to.be.bignumber.equal("15301");
   });
@@ -330,9 +385,13 @@ contract("Bank", function(_accounts) {
   it('should not liquidate overcollateralized vault', async function () {
     await this.dt.approve(this.bank.address, this.depositAmount);
     await this.bank.reserveDeposit(this.depositAmount);
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultBorrow(this.borrowAmount, {from: _accounts[1]});
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultBorrow(this.borrowAmount, { from: _accounts[1] });
+    await expectRevert(this.bank.liquidate(_accounts[1], { from: _accounts[5] }), "not keeper or admin");
+    //call as keeper
+    await expectRevert(this.bank.liquidate(_accounts[1], { from: _accounts[4] }), "VAULT NOT UNDERCOLLATERALIZED");
+    //call as admin
     await expectRevert(this.bank.liquidate(_accounts[1]), "VAULT NOT UNDERCOLLATERALIZED");
   });
 
@@ -341,13 +400,13 @@ contract("Bank", function(_accounts) {
     await this.bank.reserveDeposit(this.depositAmount);
 
     // The first price for the collateral and debt
-    await web3.eth.sendTransaction({to:this.oa,from:_accounts[0],gas:4000000,data:this.oracle2.methods.requestData("USDT","USDT/USD",1000,0).encodeABI()})
-    for(var i = 0;i <=4 ;i++){
-      await web3.eth.sendTransaction({to: this.oracle.address,from:_accounts[i],gas:4000000,data:this.oracle2.methods.submitMiningSolution("nonce", 1, 1000).encodeABI()})
+    await web3.eth.sendTransaction({ to: this.oa, from: _accounts[0], gas: 4000000, data: this.oracle2.methods.requestData("USDT", "USDT/USD", 1000, 0).encodeABI() })
+    for (var i = 0; i <= 4; i++) {
+      await web3.eth.sendTransaction({ to: this.oracle.address, from: _accounts[i], gas: 4000000, data: this.oracle2.methods.submitMiningSolution("nonce", 1, 1000).encodeABI() })
     }
-    await web3.eth.sendTransaction({to:this.oa,from:_accounts[0],gas:4000000,data:this.oracle2.methods.requestData("GLD","GLD/USD",1000,0).encodeABI()})
-    for(var i = 0;i <=4 ;i++){
-      await web3.eth.sendTransaction({to: this.oracle.address,from:_accounts[i],gas:4000000,data:this.oracle2.methods.submitMiningSolution("nonce", 2, 2000).encodeABI()})
+    await web3.eth.sendTransaction({ to: this.oa, from: _accounts[0], gas: 4000000, data: this.oracle2.methods.requestData("GLD", "GLD/USD", 1000, 0).encodeABI() })
+    for (var i = 0; i <= 4; i++) {
+      await web3.eth.sendTransaction({ to: this.oracle.address, from: _accounts[i], gas: 4000000, data: this.oracle2.methods.submitMiningSolution("nonce", 2, 2000).encodeABI() })
     }
     await this.bank.updateCollateralPrice();
     await this.bank.updateDebtPrice();
@@ -356,22 +415,22 @@ contract("Bank", function(_accounts) {
     expect(debtPrice).to.be.bignumber.equal("1000")
     expect(collateralPrice).to.be.bignumber.equal("2000")
 
-    await this.ct.approve(this.bank.address, this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultDeposit(this.depositAmount, {from: _accounts[1]});
-    await this.bank.vaultBorrow(this.largeBorrowAmount, {from: _accounts[1]});
+    await this.ct.approve(this.bank.address, this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultDeposit(this.depositAmount, { from: _accounts[1] });
+    await this.bank.vaultBorrow(this.largeBorrowAmount, { from: _accounts[1] });
     var collateralizationRatio = await this.bank.getVaultCollateralizationRatio(_accounts[1]);
     let b_amount = this.largeBorrowAmount.add(this.largeBorrowAmount.mul(new BN(ORIGINATION_FEE)).div(new BN(10000)));
     expect(collateralizationRatio).to.be.bignumber.equal(((this.depositAmount.mul(new BN(2000))).mul(new BN(10000))).div(b_amount.mul(new BN(1000))));
 
     // Lower the price of collateral, push the vault into undercollateralized
     // The first price for the collateral and debt
-    await web3.eth.sendTransaction({to:this.oa,from:_accounts[0],gas:4000000,data:this.oracle2.methods.requestData("USDT","USDT/USD",1000,0).encodeABI()})
-    for(var i = 0;i <=4 ;i++){
-      await web3.eth.sendTransaction({to: this.oracle.address,from:_accounts[i],gas:4000000,data:this.oracle2.methods.submitMiningSolution("nonce", 1, 1000).encodeABI()})
+    await web3.eth.sendTransaction({ to: this.oa, from: _accounts[0], gas: 4000000, data: this.oracle2.methods.requestData("USDT", "USDT/USD", 1000, 0).encodeABI() })
+    for (var i = 0; i <= 4; i++) {
+      await web3.eth.sendTransaction({ to: this.oracle.address, from: _accounts[i], gas: 4000000, data: this.oracle2.methods.submitMiningSolution("nonce", 1, 1000).encodeABI() })
     }
-    await web3.eth.sendTransaction({to:this.oa,from:_accounts[0],gas:4000000,data:this.oracle2.methods.requestData("GLD","GLD/USD",1000,0).encodeABI()})
-    for(var i = 0;i <=4 ;i++){
-      await web3.eth.sendTransaction({to: this.oracle.address,from:_accounts[i],gas:4000000,data:this.oracle2.methods.submitMiningSolution("nonce", 2, 1000).encodeABI()})
+    await web3.eth.sendTransaction({ to: this.oa, from: _accounts[0], gas: 4000000, data: this.oracle2.methods.requestData("GLD", "GLD/USD", 1000, 0).encodeABI() })
+    for (var i = 0; i <= 4; i++) {
+      await web3.eth.sendTransaction({ to: this.oracle.address, from: _accounts[i], gas: 4000000, data: this.oracle2.methods.submitMiningSolution("nonce", 2, 1000).encodeABI() })
     }
     await this.bank.updateCollateralPrice();
     await this.bank.updateDebtPrice();
@@ -379,7 +438,7 @@ contract("Bank", function(_accounts) {
     collateralPrice = await this.bank.getCollateralTokenPrice();
     expect(debtPrice).to.be.bignumber.equal("1000")
     expect(collateralPrice).to.be.bignumber.equal("1000")
-    const repayAmount = await this.bank.getVaultRepayAmount({from: _accounts[1]});
+    const repayAmount = await this.bank.getVaultRepayAmount({ from: _accounts[1] });
 
     collateralizationRatio = await this.bank.getVaultCollateralizationRatio(_accounts[1]);
     expect(collateralizationRatio).to.be.bignumber.equal(((this.depositAmount.mul(new BN(1000))).mul(new BN(10000))).div(b_amount.mul(new BN(1000))));
@@ -388,8 +447,8 @@ contract("Bank", function(_accounts) {
     const debtOwed = b_amount.add(b_amount.mul(new BN(LIQUIDATION_PENALTY)).mul(new BN(100)).div(new BN(100)).div(new BN(100)))
     const collateralToLiquidate = debtOwed.mul(new BN(1000)).div(new BN(1000));
 
-    const collateralAmount = await this.bank.getVaultCollateralAmount({from: _accounts[1]});
-    const debtAmount = await this.bank.getVaultDebtAmount({from: _accounts[1]});
+    const collateralAmount = await this.bank.getVaultCollateralAmount({ from: _accounts[1] });
+    const debtAmount = await this.bank.getVaultDebtAmount({ from: _accounts[1] });
     const debtReserveBalance = await this.bank.getReserveBalance();
     const collateralReserveBalance = await this.bank.getReserveCollateralBalance();
     const bankFactoryOwner = await this.bank.getBankFactoryOwner();
@@ -402,5 +461,9 @@ contract("Bank", function(_accounts) {
     expect(collateralReserveBalance).to.be.bignumber.equal(collateralToLiquidate.sub(feeAmt));
   });
 
+  it('should not update prices if not admin / price updater', async function () {
+    await expectRevert(this.bank.updateCollateralPrice({ from: _accounts[3] }), "not price updater or admin");
+    await expectRevert(this.bank.updateDebtPrice({ from: _accounts[3] }), "not price updater or admin");
+  })
 
 });


### PR DESCRIPTION
This PR will do:

- Implement role based access in bank contract
- Add sugar function to easy add and remove address from roles
- Indexed addresses in events
- Test RAC

### Some notes

Bank owner is now at role `admin`, the bank can have more admins. Only `admin` can add and remove addresses to roles.
Dedicated role to external `keepers` to make liquidations. Liquidations can also be perform by `admin` role users.
Dedicated role to external `price updaters`. Price updates can also be perform by `admin` role users.

`_bankFactoryOwner` is not part of role system. Don't feel that it should be a role based function. 
 
 